### PR TITLE
Fix stringify function to not prepend comment prefix for blank lines

### DIFF
--- a/stringify.js
+++ b/stringify.js
@@ -132,7 +132,7 @@ function stringify (input, {
     .map(line => Array.isArray(line) ? (
       foldLine(escapeKey(line[0]) + keySep + escapeValue(line[1]))
     ) : (
-      foldComment(String(line || '').replace(/^\s*([#!][ \t\f]*)?/g, commentPrefix))
+      line === '' ? line : foldComment(String(line || '').replace(/^\s*([#!][ \t\f]*)?/g, commentPrefix))
     ))
     .join(newline)
 }

--- a/tests/corner-cases.tests.js
+++ b/tests/corner-cases.tests.js
@@ -65,6 +65,13 @@ deserunt mollit anim id est laborum.`
     expect(stringify([lorem])).toBe(lorem.replace(/\r\n/gm, '\n# ').trim())
     expect(stringify([['key', lorem]])).toBe('key = ' + lorem.replace(/\r\n/g, '\\r\\n\\\n    '))
   })
+
+  test('lines with empty strings result in blank lines', () => {
+    const emptyLine = ''
+    expect(stringify([emptyLine])).toBe(emptyLine)
+    const lines = [['key1', 'value1'], '', ['key2', 'value2']];
+    expect(stringify(lines)).toBe('key1 = value1\n\nkey2 = value2')
+  })
 })
 
 describe('default values', () => {


### PR DESCRIPTION
IMO, the stringify function should allow the inverse of what parseLines does regarding blank lines. That is, if parseLines outputs an array with an empty string for each blank line it finds, the stringify function should do the inverse operation, and output a blank line for each array with just an empty string in it.